### PR TITLE
adding openzeppelin libraries by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
     "prettier": "^2.3.1",
     "prettier-plugin-solidity": "^1.0.0-beta.13",
     "solhint": "^3.3.6"
+  },
+  "dependencies": {
+    "@openzeppelin/contracts": "^4.3.0"
   }
 }


### PR DESCRIPTION
It would be could to have it there, since we mostly use it for more faster, more secure smart contracts developpement.